### PR TITLE
:sparkles: Implements simple Lua configure(Many to do)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -229,7 +229,7 @@ checksum = "fdde5c9cd29ebd706ce1b35600920a33550e402fc998a2e53ad3b42c3c47a192"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.27",
+ "syn 2.0.28",
 ]
 
 [[package]]
@@ -330,7 +330,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.27",
+ "syn 2.0.28",
 ]
 
 [[package]]
@@ -1205,7 +1205,7 @@ dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 2.0.27",
+ "syn 2.0.28",
 ]
 
 [[package]]
@@ -1516,9 +1516,12 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "serde"
-version = "1.0.177"
+version = "1.0.183"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "63ba2516aa6bf82e0b19ca8b50019d52df58455d3cf9bdaf6315225fdd0c560a"
+checksum = "32ac8da02677876d532745a130fc9d8e6edfa81a269b107c5b00829b91d8eb3c"
+dependencies = [
+ "serde_derive",
+]
 
 [[package]]
 name = "serde-value"
@@ -1532,13 +1535,13 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.177"
+version = "1.0.183"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "401797fe7833d72109fedec6bfcbe67c0eed9b99772f26eb8afd261f0abc6fd3"
+checksum = "aafe972d60b0b9bee71a91b92fee2d4fb3c9d7e8f6b179aa99f27203d99a4816"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.27",
+ "syn 2.0.28",
 ]
 
 [[package]]
@@ -1680,11 +1683,11 @@ dependencies = [
  "clap",
  "colored",
  "crossbeam-channel",
+ "lazy_static",
  "log",
  "mlua",
  "once_cell",
  "serde",
- "serde_derive",
  "smithay",
  "smithay-drm-extras",
  "tokio",
@@ -1711,9 +1714,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.27"
+version = "2.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b60f673f44a8255b9c8c657daf66a596d435f2da81a555b06dc644d080ba45e0"
+checksum = "04361975b3f5e348b2189d8dc55bc942f278b2d482a6a0365de5bdd62d351567"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1750,7 +1753,7 @@ checksum = "090198534930841fab3a5d1bb637cde49e339654e606195f8d9c76eeb081dc96"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.27",
+ "syn 2.0.28",
 ]
 
 [[package]]
@@ -1829,7 +1832,7 @@ checksum = "630bdcf245f78637c13ec01ffae6187cca34625e8c63150d424b59e55af2675e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.27",
+ "syn 2.0.28",
 ]
 
 [[package]]
@@ -1880,7 +1883,7 @@ checksum = "5f4f31f56159e98206da9efd823404b79b6ef3143b4a7ab76e67b1751b25a4ab"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.27",
+ "syn 2.0.28",
 ]
 
 [[package]]
@@ -1996,7 +1999,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.27",
+ "syn 2.0.28",
  "wasm-bindgen-shared",
 ]
 
@@ -2018,7 +2021,7 @@ checksum = "54681b18a46765f095758388f2d0cf16eb8d4169b639ab575a8f5693af210c7b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.27",
+ "syn 2.0.28",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,6 @@ categories = ["linux-utilities"]
 [dependencies]
 tracing-subscriber = { features = ["env-filter"], version = "0.3.17" }
 bitflags = "2.2.1"
-serde_derive = "1.0.164"
 colored = "2.0.0"
 clap = { version = "4.3.11", features = ["derive"] }
 anyhow = "1.0.71"
@@ -31,7 +30,7 @@ log = "0.4.19"
 tokio = { version = "1.29.1", features = ["full"] }
 chrono = "0.4.26"
 tracing-appender = "0.2.2"
-serde = "1.0.171"
+serde = { version = "1.0.183", features = ["derive"] }
 smithay-drm-extras = { git = "https://github.com/Smithay/smithay.git" }
 once_cell = "1.18.0"
 crossbeam-channel = "0.5.8"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,8 @@ serde = "1.0.171"
 smithay-drm-extras = { git = "https://github.com/Smithay/smithay.git" }
 once_cell = "1.18.0"
 crossbeam-channel = "0.5.8"
-mlua = { version = "0.9.0-rc.2", features = ["lua54", "vendored", "serialize"] }
+mlua = { version = "0.9.0-rc.2", features = ["lua54", "vendored", "serialize", "send"] }
+lazy_static = "1.4.0"
 
 [dependencies.smithay]
 git = "https://github.com/smithay/smithay"

--- a/src/libs/backends/winit.rs
+++ b/src/libs/backends/winit.rs
@@ -106,7 +106,7 @@ pub fn init_winit() {
 		.unwrap();
 
 	// Autostart applications
-	for cmd in &CONFIG.autostart.cmd {
+	for cmd in &CONFIG.lock().unwrap().autostart.cmd {
 		let cmd = &cmd.cmd;
 		let args: Vec<_> = cmd.split(" ").collect();
 		Command::new("/bin/sh").arg("-c").args(&args[0..]).spawn().ok();

--- a/src/libs/backends/winit.rs
+++ b/src/libs/backends/winit.rs
@@ -107,7 +107,6 @@ pub fn init_winit() {
 
 	// Autostart applications
 	for cmd in &CONFIG.lock().unwrap().autostart.cmd {
-		let cmd = &cmd.cmd;
 		let args: Vec<_> = cmd.split(" ").collect();
 		Command::new("/bin/sh").arg("-c").args(&args[0..]).spawn().ok();
 	}

--- a/src/libs/decorations/borders.rs
+++ b/src/libs/decorations/borders.rs
@@ -80,7 +80,7 @@ impl BorderShader {
 		window: &Window,
 		loc: Point<i32, Logical>,
 	) -> PixelShaderElement {
-		let thickness: f32 = CONFIG.window_decorations.border_width as f32;
+		let thickness: f32 = CONFIG.lock().unwrap().window_decorations.border_width as f32;
 		let thickness_loc = (thickness as i32, thickness as i32);
 		let thickness_size = ((thickness * 2.0) as i32, (thickness * 2.0) as i32);
 		let geo = Rectangle::from_loc_and_size(
@@ -102,7 +102,7 @@ impl BorderShader {
 		} else {
 			let angle = 45 as f32 * std::f32::consts::PI;
 			let gradient_direction = [angle.cos(), angle.sin()];
-			let elem = if CONFIG.window_decorations.border_radius > 0.0 {
+			let elem = if CONFIG.lock().unwrap().window_decorations.border_radius > 0.0 {
 				PixelShaderElement::new(
 					Self::get(renderer).rounded.clone(),
 					geo,
@@ -118,7 +118,8 @@ impl BorderShader {
 						Uniform::new("halfThickness", thickness * 0.5),
 						Uniform::new(
 							"radius",
-							CONFIG.window_decorations.border_radius as f32 + thickness + 2.0,
+							CONFIG.lock().unwrap().window_decorations.border_radius as f32
+								+ thickness + 2.0,
 						),
 						Uniform::new("gradientDirection", gradient_direction),
 					],

--- a/src/libs/parse_config.rs
+++ b/src/libs/parse_config.rs
@@ -1,30 +1,180 @@
-use crate::libs::structs::config::Config;
+use crate::libs::structs::config::*;
 use mlua::{
 	Function,
 	Lua,
 	Result,
+	Table,
+	Value,
 };
 use std::{
-	collections::HashMap,
 	env::var,
 	fs::read_to_string,
 };
 
-pub fn parse_config() -> Result<(Config, HashMap<Vec<String>, Function>)> {
+struct StrataApi;
+
+impl StrataApi {
+	pub fn spawn(_: &Lua, cmd: String) -> Result<()> {
+		println!("Spawning {}", cmd.to_string());
+		Ok(())
+	}
+}
+
+pub struct Stratacmd;
+
+impl Stratacmd {
+	pub fn spawn(lua: &Lua, cmd: String) -> Result<Function> {
+		let func = lua
+			.load(format!(
+				r#"
+            local strata = require("strata")
+            strata.api.spawn("{}")"#,
+				cmd
+			))
+			.into_function()?;
+		Ok(func)
+	}
+
+	pub fn set_bindings(lua: &Lua, bindings: Table) -> Result<()> {
+		for key in bindings.sequence_values::<Table>() {
+			let table: Table = key?.clone();
+			let keys: Vec<String> = table.get("keys")?;
+			let cmd: Function = table.get("cmd")?;
+			let _ = lua
+				.globals()
+				.get::<&str, Table>("package")?
+				.get::<&str, Table>("loaded")?
+				.get::<&str, Table>("strata")?
+				.get::<&str, Table>("bindings")?
+				.set(keys.clone().concat(), cmd)?;
+			CONFIG
+				.lock()
+				.unwrap()
+				.bindings
+				.push(Keybinding { keys: keys.clone(), func: keys.clone().concat() });
+		}
+		Ok(())
+	}
+	pub fn set_rules(lua: &Lua, rules: Table) -> Result<()> {
+		for rule in rules.sequence_values::<Table>() {
+			let table: Table = rule?.clone();
+			let rules_triggers: Table = table.clone().get::<&str, Table>("triggers").ok().unwrap();
+			for trigger in rules_triggers.sequence_values::<Table>() {
+				let trigger = trigger?.clone();
+				let triggers_event: String = trigger.get("event").ok().unwrap();
+				let triggers_classname: String = trigger.get("class_name").ok().unwrap();
+				let triggers_workspace: Option<Option<i32>> = trigger.get("workspace")?;
+				let trigger = match triggers_workspace {
+					Some(value) => {
+						Triggers {
+							event: triggers_event.clone(),
+							class_name: triggers_classname.clone(),
+							workspace: value.clone(),
+						}
+					}
+					None => {
+						Triggers {
+							event: triggers_event.clone(),
+							class_name: triggers_classname.clone(),
+							workspace: None,
+						}
+					}
+				};
+				let action_name: String = format!(
+					"{}{}{}",
+					trigger.clone().event,
+					trigger.class_name,
+					trigger.workspace.unwrap()
+				);
+				let action: Function = table.get("action").ok().unwrap();
+				println!("{:#?} {:#?}", trigger, action);
+				let _ = lua
+					.globals()
+					.get::<&str, Table>("package")?
+					.get::<&str, Table>("loaded")?
+					.get::<&str, Table>("strata")?
+					.get::<&str, Table>("bindings")?
+					.set(action_name.clone(), action)?;
+				CONFIG
+					.lock()
+					.unwrap()
+					.rules
+					.push(Rules { triggers: trigger.clone(), action: action_name });
+			}
+		}
+
+		Ok(())
+	}
+}
+
+pub fn parse_config() -> Result<()> {
 	let lua = Lua::new();
 	let config_path =
 		format!("{}/.config/strata/strata.lua", var("HOME").expect("This should always be set!!!"));
 	let config_str = read_to_string(config_path).unwrap();
+
+	// Create a new module
+	let strata_mod = get_or_create_module(&lua, "strata").ok().unwrap();
+	let cmd_submod = get_or_create_sub_module(&lua, "cmd").ok().unwrap();
+	let api_submod = get_or_create_sub_module(&lua, "api").ok().unwrap();
+	let _submod = get_or_create_sub_module(&lua, "bindings").ok().unwrap();
+
+	// Create "spawn config" for strata.cmd to construct Function and use it later.
+	cmd_submod.set("spawn", lua.create_function(Stratacmd::spawn).ok().unwrap())?;
+	// Create "spawn api" for strata.api that can triggers Function as needed.
+	api_submod.set("spawn", lua.create_function(StrataApi::spawn).ok().unwrap())?;
+
+	strata_mod.set("set_bindings", lua.create_function(Stratacmd::set_bindings).ok().unwrap())?;
+	strata_mod.set("set_rules", lua.create_function(Stratacmd::set_rules).ok().unwrap())?;
+
+	lua.load(&config_str).exec().ok();
+
+	Ok(())
+}
+
+pub fn get_or_create_module<'lua>(lua: &'lua Lua, name: &str) -> anyhow::Result<mlua::Table<'lua>> {
 	let globals = lua.globals();
-	let strata: mlua::Table = lua.load("return require('strata')").eval()?;
-	globals.set("strata", strata)?;
-	let config: Config = lua.load(&config_str).eval()?;
-	let bindings: mlua::Table = lua.load("return bindings").eval()?;
-	let mut keybindings = HashMap::new();
-	for pair in bindings.pairs::<mlua::Table, Function>() {
-		let (key, func) = pair?;
-		let key_combo: Vec<String> = key.sequence_values().collect::<Result<Vec<String>>>()?;
-		keybindings.insert(key_combo, func);
+	let package: Table = globals.get("package")?;
+	let loaded: Table = package.get("loaded")?;
+
+	let module = loaded.get(name)?;
+	match module {
+		Value::Nil => {
+			let module = lua.create_table()?;
+			loaded.set(name, module.clone())?;
+			Ok(module)
+		}
+		Value::Table(table) => Ok(table),
+		wat => {
+			anyhow::bail!(
+				"cannot register module {} as package.loaded.{} is already set to a value of type \
+				 {}",
+				name,
+				name,
+				wat.type_name()
+			)
+		}
 	}
-	Ok((config, keybindings))
+}
+
+pub fn get_or_create_sub_module<'lua>(
+	lua: &'lua Lua,
+	name: &str,
+) -> anyhow::Result<mlua::Table<'lua>> {
+	let strata_mod = get_or_create_module(lua, "strata")?;
+	let sub = strata_mod.get(name)?;
+	match sub {
+		Value::Nil => {
+			let sub = lua.create_table()?;
+			strata_mod.set(name, sub.clone())?;
+			Ok(sub)
+		}
+		Value::Table(sub) => Ok(sub),
+		wat => {
+			anyhow::bail!(
+				"cannot register module strata.{name} as it is already set to a value of type {}",
+				wat.type_name()
+			)
+		}
+	}
 }

--- a/src/libs/state.rs
+++ b/src/libs/state.rs
@@ -93,18 +93,18 @@ impl<BackendData: Backend> StrataState<BackendData> {
 		let mut seat = seat_state.new_wl_seat(&dh, seat_name.clone());
 		let layer_shell_state = WlrLayerShellState::new::<Self>(&dh);
 
-		if !CONFIG.general.kb_repeat.is_empty() {
+		if !CONFIG.lock().unwrap().general.kb_repeat.is_empty() {
 			seat.add_keyboard(
 				XkbConfig::default(),
-				CONFIG.general.kb_repeat[0],
-				CONFIG.general.kb_repeat[1],
+				CONFIG.lock().unwrap().general.kb_repeat[0],
+				CONFIG.lock().unwrap().general.kb_repeat[1],
 			)
 			.expect("Couldn't parse XKB config");
 		} else {
 			seat.add_keyboard(XkbConfig::default(), 500, 250).expect("Couldn't parse XKB config");
 		}
 		seat.add_pointer();
-		let workspaces = Workspaces::new(CONFIG.general.workspaces);
+		let workspaces = Workspaces::new(CONFIG.lock().unwrap().general.workspaces);
 		let socket_name = Self::init_wayland_listener(&mut loop_handle, display);
 
 		Self {

--- a/src/libs/structs/config.rs
+++ b/src/libs/structs/config.rs
@@ -1,24 +1,21 @@
 use lazy_static::lazy_static;
-use serde_derive::Deserialize;
+use serde::Deserialize;
 use std::sync::Mutex;
 lazy_static! {
 	pub static ref CONFIG: Mutex<Config> = Mutex::new(Config::default());
 }
 
-#[derive(Debug, Deserialize)]
-pub struct AutostartCmd {
-	pub cmd: String,
-}
-
 #[derive(Debug, Deserialize, Default)]
 pub struct Autostart {
-	pub cmd: Vec<AutostartCmd>,
+	pub cmd: Vec<String>,
 }
 
 #[derive(Debug, Default, Deserialize)]
 pub struct General {
 	pub workspaces: u8,
+    #[serde(rename="gaps_in")]
 	pub in_gaps: i32,
+    #[serde(rename="gaps_out")]
 	pub out_gaps: i32,
 	pub kb_repeat: Vec<i32>,
 }
@@ -33,7 +30,9 @@ pub struct WindowDecorations {
 	pub blur_enable: bool,
 	pub blur_size: u32,
 	pub blur_passes: u32,
+    #[serde(rename="blur_optimize")]
 	pub blur_optimization: bool,
+    #[serde(rename="shadow_enabled")]
 	pub shadows_enabled: bool,
 	pub shadow_size: u32,
 	pub shadow_blur: u32,
@@ -47,6 +46,7 @@ pub struct Tiling {
 
 #[derive(Debug, Default, Deserialize)]
 pub struct Animations {
+    #[serde(rename="enabled")]
 	pub anim_enabled: bool,
 }
 
@@ -81,3 +81,4 @@ pub struct Config {
 }
 
 unsafe impl Send for Config {}
+

--- a/src/libs/structs/config.rs
+++ b/src/libs/structs/config.rs
@@ -1,19 +1,21 @@
-use crate::libs::parse_config::parse_config;
-use mlua::Function;
-use once_cell::sync::Lazy;
+use lazy_static::lazy_static;
 use serde_derive::Deserialize;
+use std::sync::Mutex;
+lazy_static! {
+	pub static ref CONFIG: Mutex<Config> = Mutex::new(Config::default());
+}
 
-#[derive(Debug)]
+#[derive(Debug, Deserialize)]
 pub struct AutostartCmd {
 	pub cmd: String,
 }
 
-#[derive(Debug)]
+#[derive(Debug, Deserialize, Default)]
 pub struct Autostart {
 	pub cmd: Vec<AutostartCmd>,
 }
 
-#[derive(Debug)]
+#[derive(Debug, Default, Deserialize)]
 pub struct General {
 	pub workspaces: u8,
 	pub in_gaps: i32,
@@ -21,7 +23,7 @@ pub struct General {
 	pub kb_repeat: Vec<i32>,
 }
 
-#[derive(Debug)]
+#[derive(Debug, Default, Deserialize)]
 pub struct WindowDecorations {
 	pub border_width: u32,
 	pub border_active: String,
@@ -38,48 +40,44 @@ pub struct WindowDecorations {
 	pub shadow_color: String,
 }
 
-#[derive(Debug)]
+#[derive(Debug, Default, Deserialize)]
 pub struct Tiling {
 	pub layout: String,
 }
 
-#[derive(Debug)]
+#[derive(Debug, Default, Deserialize)]
 pub struct Animations {
 	pub anim_enabled: bool,
 }
 
-#[derive(Debug)]
-pub struct Workspace {
-	pub workspace: i32,
+#[derive(Debug, Deserialize, Clone)]
+pub struct Triggers {
+	pub event: String,
 	pub class_name: String,
+	pub workspace: Option<i32>,
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct Rules {
-	pub workspace: Vec<Workspace>,
-	pub floating: Vec<Floating>,
+	pub triggers: Triggers,
+	pub action: String,
 }
 
-#[derive(Debug)]
-pub struct Floating {
-	pub class_name: String,
-}
-
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct Keybinding {
 	pub keys: Vec<String>,
-	pub func: Function,
+	pub func: String,
 }
 
-#[derive(Debug)]
+#[derive(Debug, Default)]
 pub struct Config {
 	pub autostart: Autostart,
 	pub general: General,
 	pub window_decorations: WindowDecorations,
 	pub tiling: Tiling,
 	pub animations: Animations,
-	pub rules: Rules,
+	pub rules: Vec<Rules>,
 	pub bindings: Vec<Keybinding>,
 }
 
-pub static CONFIG: Lazy<Config> = Lazy::new(parse_config);
+unsafe impl Send for Config {}

--- a/src/libs/tiling.rs
+++ b/src/libs/tiling.rs
@@ -24,7 +24,7 @@ use smithay::{
 };
 
 pub fn refresh_geometry(workspace: &mut Workspace) {
-	let gaps = (CONFIG.general.out_gaps, CONFIG.general.in_gaps);
+	let gaps = (CONFIG.lock().unwrap().general.out_gaps, CONFIG.lock().unwrap().general.in_gaps);
 	let output = layer_map_for_output(workspace.outputs().next().unwrap()).non_exclusive_zone();
 	let output_full = workspace.outputs().next().unwrap().current_mode().unwrap().size;
 

--- a/src/libs/workspaces.rs
+++ b/src/libs/workspaces.rs
@@ -55,7 +55,6 @@ impl StrataWindow {
 		self.rec.loc - self.window.geometry().loc
 	}
 }
-
 impl Workspace {
 	pub fn new() -> Self {
 		Workspace { windows: Vec::new(), outputs: Vec::new(), layout_tree: Dwindle::new() }
@@ -104,7 +103,7 @@ impl Workspace {
 		let mut render_elements: Vec<C> = Vec::new();
 		for element in &self.windows {
 			let window = &element.borrow().window;
-			if CONFIG.window_decorations.border_width > 0 {
+			if CONFIG.lock().unwrap().window_decorations.border_width > 0 {
 				render_elements.push(C::from(BorderShader::element(
 					renderer.glow_renderer_mut(),
 					window,

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,22 +6,16 @@ pub use libs::{
 	parse_config::parse_config,
 	structs::{
 		args::Args,
-		state::{
-			CalloopData,
-			StrataState,
-		},
+		state::{CalloopData, StrataState},
 	},
 };
 use log::info;
-use std::{
-	env::var,
-	error::Error,
-	io::stdout,
-};
+use std::{env::var, error::Error, io::stdout};
 use tracing_subscriber::fmt::writer::MakeWriterExt;
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn Error>> {
+	let _ = tokio::spawn(async move { parse_config() });
 	let log_dir =
 		format!("{}/.strata/stratawm", var("HOME").expect("This variable should be set!!!"));
 	let file_appender = tracing_appender::rolling::never(
@@ -38,7 +32,6 @@ async fn main() -> Result<(), Box<dyn Error>> {
 		tracing_subscriber::fmt().with_writer(log_appender).init();
 	}
 
-    let _ = parse_config();
 	let args = Args::parse();
 
 	init_with_backend(&args.backend);

--- a/src/main.rs
+++ b/src/main.rs
@@ -38,6 +38,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
 		tracing_subscriber::fmt().with_writer(log_appender).init();
 	}
 
+    let _ = parse_config();
 	let args = Args::parse();
 
 	init_with_backend(&args.backend);

--- a/strata.default.lua
+++ b/strata.default.lua
@@ -11,18 +11,18 @@ end
 -- unknown global variables.
 -- Can also be written that way:
 --     strata.set_bindings({ ... })
-strata.set_bindings {
-	{
-		keys = { "CTRL", "SHIFT", "Q" },
-		cmd = close_all_windows,
-	},
-	{
-		keys = { "WIN", "RETURN" },
-		-- `strata.cmd` should contain a bunch of common built-in functions that generate callbacks to be used
-		-- here, so that the boilerplate is reduced for most use-cases.
-		cmd = strata.cmd.spawn("kitty --title Terminal"),
-	},
-}
+-- strata.set_bindings {
+-- 	{
+-- 		keys = { "CTRL", "SHIFT", "Q" },
+-- 		cmd = close_all_windows,
+-- 	},
+-- 	{
+-- 		keys = { "WIN", "RETURN" },
+-- 		-- `strata.cmd` should contain a bunch of common built-in functions that generate callbacks to be used
+-- 		-- here, so that the boilerplate is reduced for most use-cases.
+-- 		cmd = strata.cmd.spawn("kitty --title Terminal"),
+-- 	},
+-- }
 
 -- This is my take to improve the "rules" system and make it much more flexible.
 -- It's a simple association between a trigger, and an action. Honestly, the whole `set_bindings` function could be
@@ -31,78 +31,70 @@ strata.set_bindings {
 -- This is very close to how neovim handles events with autocmds. I guess it would make sense to add an optional `group`
 -- parameter as well here, so that we can bundle multiple rules together and disable them all at once with another
 -- function (this is useful for plugins).
-strata.set_rules {
-	-- Always bind firefox to the workspace 1, before the window is opened
-	{
-		triggers = { event = "win_open_pre", class_name = "firefox" },
-		action = function(window) window.send_to_workspace(1) end,
-	},
+-- strata.set_rules {
+-- 	-- Always bind firefox to the workspace 1, before the window is opened
+-- 	{
+-- 		triggers = { { event = "win_open_pre", class_name = "firefox" } },
+-- 		action = function(window) window.send_to_workspace(1) end,
+-- 	},
+--
+-- 	-- A single action that can be ran from multiple triggers.
+-- 	{
+-- 		triggers = {
+-- 			-- Set mpv to floating, always
+-- 			{ event = "win_open_pre", class_name = "mpv" },
+-- 			-- Set terminals to floating only if on the workspace 1 (where we put firefox previously)
+-- 			{ event = "win_open_pre", workspace = 1, class_name = "kitty" },
+-- 		},
+-- 		action = function(window) window.set_floating() end,
+-- 	},
 
-	-- A single action that can be ran from multiple triggers.
-	{
-		triggers = {
-			-- Set mpv to floating, always
-			{ event = "win_open_pre", class_name = "mpv" },
-			-- Set terminals to floating only if on the workspace 1 (where we put firefox previously)
-			{ event = "win_open_pre", workspace = 1, class_name = { "kitty", "wezterm" } },
-		},
-		action = function(window) window.set_floating() end,
-	},
+-- Here comes the nice stuff: helper functions! This is important, as these functions help make the config file much
+-- easier to write for the majority of users. Ideally, most people won't ever need to write something detailed like
+-- what's above.
 
-	-- Here comes the nice stuff: helper functions! This is important, as these functions help make the config file much
-	-- easier to write for the majority of users. Ideally, most people won't ever need to write something detailed like
-	-- what's above.
-
-	-- This one does the same thing as the first rule
-	strata.rules.bind_to_workspace(1, "firefox"),
-
-	-- Nothing preventing us from some more sugar, to make things even less verbose:
-	strata.rules.bind_to_workspace {
-		{ 1, "firefox" },
-		{ 2, "neovide" },
-		{ 10, "slack" },
-	},
-
-	-- This does the same thing as the first trigger of the second rule
-	strata.rules.set_floating("mpv"),
-}
+-- This one does the same thing as the first rule
+-- strata.rules.bind_to_workspace(1, "firefox"),
+--
+-- -- Nothing preventing us from some more sugar, to make things even less verbose:
+-- strata.rules.bind_to_workspace({
+-- 	{ 1, "firefox" },
+-- 	{ 2, "neovide" },
+-- 	{ 10, "slack" },
+-- }),
+--
+-- -- This does the same thing as the first trigger of the second rule
+-- strata.rules.set_floating("mpv"),
+-- }
 
 -- Same as above, this is a function call. I think as it stands it should *overwrite* the whole config every time it's
 -- called. For a "merge" behavior, we could have a `strata.update_config()` function instead. This can one day be useful
 -- for plugins.
 strata.set_config {
 	autostart = {
-		{ "kitty", "--title", "Terminal" },
+		{ "kitty --title Terminal" },
 		{ "kagi" },
 	},
 	general = {
-		workspaces = 1,
+		workspaces = 10,
 		gaps_in = 8,
 		gaps_out = 12,
 		kb_repeat = { 500, 250 },
 	},
 	decorations = {
-		border = {
-			width = 2,
-			active = "#FFF",
-			inactive = "#131418",
-			radius = 5,
-		},
-		window = {
-			opacity = 0.9,
-		},
-		blur = {
-			enabled = true,
-			size = 2,
-			passes = 3,
-			optimize = true,
-		},
-		shadow = {
-			enabled = true,
-			size = 2,
-			blur = 3,
-			color = "#FFF",
-		},
+		border_width = 2,
+		border_active = "#FFF",
+		border_inactive = "#131418",
+		border_radius = 5,
+		window_opacity = 0.9,
+		blur_enable = true,
+		blur_size = 2,
+		blur_passes = 3,
+		blur_optimize = true,
+		shadow_enabled = true,
+		shadow_size = 2,
+		shadow_blur = 3,
+		shadow_color = "#FFF",
 	},
 	tiling = {
 		layout = "dwindle",
@@ -112,6 +104,33 @@ strata.set_config {
 	},
 
 	-- I guess we can have the same systems as above here for convenience for most users:
-	bindings = { ... }, -- same thing as the argument for `strata.set_bindings()`
-	rules = { ... }, -- same thing as the argument for `strata.set_rules()`
+	bindings = {
+		{
+			keys = { "CTRL", "SHIFT", "Q" },
+			cmd = close_all_windows,
+		},
+		{
+			keys = { "WIN", "RETURN" },
+			-- `strata.cmd` should contain a bunch of common built-in functions that generate callbacks to be used
+			-- here, so that the boilerplate is reduced for most use-cases.
+			cmd = strata.cmd.spawn("kitty --title Terminal"),
+		},
+	}, -- same thing as the argument for `strata.set_bindings()`
+	rules = {
+		{
+			triggers = { { event = "win_open_pre", class_name = "firefox" } },
+			action = function(window) window.send_to_workspace(1) end,
+		},
+
+		-- A single action that can be ran from multiple triggers.
+		{
+			triggers = {
+				-- Set mpv to floating, always
+				{ event = "win_open_pre", class_name = "mpv" },
+				-- Set terminals to floating only if on the workspace 1 (where we put firefox previously)
+				{ event = "win_open_pre", workspace = 1, class_name = "kitty" },
+			},
+			action = function(window) window.set_floating() end,
+		},
+	}, -- same thing as the argument for `strata.set_rules()`
 }


### PR DESCRIPTION
I have made `strata.cmd.spawn` to make `LuaFunction` and stored it in a `LuaTable` on `strata.bindings` named by it's setting's keys which will be excute the pre-defined `strata.api` function that we can use everywhere.

This maybe our standard implementation for loading lua config as we need to make more function like `strata.rules.set_floating()` `strata.rules.bind_to_workspace()` `strata.set_config()` and `strata.update_config()` and more in the future.

also we need more `strata.cmd` and `strata.api` function as much as we can think of.