### PR TITLE
:wrench: Fixed blocking code

### DIFF
--- a/src/libs/parse_config.rs
+++ b/src/libs/parse_config.rs
@@ -135,8 +135,6 @@ pub fn parse_config() -> Result<()> {
 	strata_mod.set("set_config", lua.create_function(Stratacmd::set_config).ok().unwrap())?;
 
 	lua.load(&config_str).exec().ok();
-    let configs = CONFIG.lock().unwrap();
-    println!("{:#?}", configs);
 
 	Ok(())
 }

--- a/src/libs/state.rs
+++ b/src/libs/state.rs
@@ -92,19 +92,17 @@ impl<BackendData: Backend> StrataState<BackendData> {
 		let seat_name = backend_data.seat_name();
 		let mut seat = seat_state.new_wl_seat(&dh, seat_name.clone());
 		let layer_shell_state = WlrLayerShellState::new::<Self>(&dh);
-
+		let key_delay: i32 = CONFIG.lock().unwrap().general.kb_repeat[0];
+		let key_repeat: i32 = CONFIG.lock().unwrap().general.kb_repeat[1];
 		if !CONFIG.lock().unwrap().general.kb_repeat.is_empty() {
-			seat.add_keyboard(
-				XkbConfig::default(),
-				CONFIG.lock().unwrap().general.kb_repeat[0],
-				CONFIG.lock().unwrap().general.kb_repeat[1],
-			)
-			.expect("Couldn't parse XKB config");
+			seat.add_keyboard(XkbConfig::default(), key_delay, key_repeat)
+				.expect("Couldn't parse XKB config");
 		} else {
 			seat.add_keyboard(XkbConfig::default(), 500, 250).expect("Couldn't parse XKB config");
 		}
 		seat.add_pointer();
-		let workspaces = Workspaces::new(CONFIG.lock().unwrap().general.workspaces);
+		let config_workspace: u8 = CONFIG.lock().unwrap().general.workspaces.clone();
+		let workspaces = Workspaces::new(config_workspace);
 		let socket_name = Self::init_wayland_listener(&mut loop_handle, display);
 
 		Self {

--- a/src/libs/structs/config.rs
+++ b/src/libs/structs/config.rs
@@ -1,8 +1,11 @@
 use lazy_static::lazy_static;
 use serde::Deserialize;
-use std::sync::Mutex;
+use std::sync::{
+	Arc,
+	Mutex,
+};
 lazy_static! {
-	pub static ref CONFIG: Mutex<Config> = Mutex::new(Config::default());
+	pub static ref CONFIG: Arc<Mutex<Config>> = Arc::new(Mutex::new(Config::default()));
 }
 
 #[derive(Debug, Deserialize, Default)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -15,7 +15,7 @@ use tracing_subscriber::fmt::writer::MakeWriterExt;
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn Error>> {
-	let _ = tokio::spawn(async move { parse_config() });
+	let _ = tokio::spawn(async move { parse_config() }).await.unwrap();
 	let log_dir =
 		format!("{}/.strata/stratawm", var("HOME").expect("This variable should be set!!!"));
 	let file_appender = tracing_appender::rolling::never(


### PR DESCRIPTION
Some good news here, after digging down to find the blocking code for a while I founded it! it's where we try to `lock()` 2 times in a rows cuz that `second lock` to `wait forever`. 
Here we launch it!

![2023-08-14T06:02:14,939300812+07:00](https://github.com/StrataWM/stratawm/assets/8637706/7e67d72d-5982-49d6-9e58-a720a1e3a93a)

Another thing I found is this. but I'm not familiar with xdg-shell and desktop part so I think I'll work on another branch to re-construct the config.

![image](https://github.com/StrataWM/stratawm/assets/8637706/63af6ea9-812d-4b80-b80b-642450e7797f)
