### PR TITLE
use xdg to get proper paths and fix config parsing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -19,9 +19,9 @@ checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
 
 [[package]]
 name = "aho-corasick"
-version = "1.0.3"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86b8f9420f797f2d9e935edf629310eb938a0d839f984e25327f3c7eed22300c"
+checksum = "6748e8def348ed4d14996fa801f4122cd763fff530258cdc03f64b25f89d3a5a"
 dependencies = [
  "memchr",
 ]
@@ -116,9 +116,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.72"
+version = "1.0.75"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b13c32d80ecc7ab747b80c3784bce54ee8a7a0cc4fbda9bf4cda2cf6fe90854"
+checksum = "a4668cab20f66d8d020e1fbc0ebe47217433c1b6c8f2040faf858554e394ace6"
 
 [[package]]
 name = "appendlist"
@@ -229,7 +229,7 @@ checksum = "fdde5c9cd29ebd706ce1b35600920a33550e402fc998a2e53ad3b42c3c47a192"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.28",
+ "syn 2.0.29",
 ]
 
 [[package]]
@@ -301,9 +301,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.3.21"
+version = "4.3.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c27cdf28c0f604ba3f512b0c9a409f8de8513e4816705deb0498b627e7c3a3fd"
+checksum = "03aef18ddf7d879c15ce20f04826ef8418101c7e528014c3eeea13321047dca3"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -312,9 +312,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.3.21"
+version = "4.3.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08a9f1ab5e9f01a9b81f202e8562eb9a10de70abf9eaeac1be465c28b75aa4aa"
+checksum = "f8ce6fffb678c9b80a70b6b6de0aad31df727623a70fd9a842c30cd573e2fa98"
 dependencies = [
  "anstream",
  "anstyle",
@@ -331,7 +331,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.28",
+ "syn 2.0.29",
 ]
 
 [[package]]
@@ -565,9 +565,9 @@ checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
 
 [[package]]
 name = "erased-serde"
-version = "0.3.28"
+version = "0.3.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da96524cc884f6558f1769b6c46686af2fe8e8b4cd253bd5a3cdba8181b8e070"
+checksum = "fc978899517288e3ebbd1a3bfc1d9537dbb87eeab149e53ea490e63bcdff561a"
 dependencies = [
  "serde",
 ]
@@ -962,9 +962,9 @@ dependencies = [
 
 [[package]]
 name = "luajit-src"
-version = "210.4.7+resty107baaf"
+version = "210.4.8+resty107baaf"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca76a3752fc130e5dabef71792f4f7095babb72f7c85860c7830eb746ad8bf31"
+checksum = "e05167e8b2a2185758d83ed23541e5bd8bce37072e4204e0ef2c9b322bc87c4e"
 dependencies = [
  "cc",
  "which",
@@ -1050,9 +1050,9 @@ dependencies = [
 
 [[package]]
 name = "mlua"
-version = "0.9.0-rc.3"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01a6500a9fb74b519a85ac206cd57f9f91b270ce39d6cb12ab06a8ed29c3563d"
+checksum = "5d6356d163eb2ebaa9caafc3a3ed6aedc686128e913557cd3a5591fd4cd726f5"
 dependencies = [
  "bstr",
  "erased-serde",
@@ -1068,9 +1068,9 @@ dependencies = [
 
 [[package]]
 name = "mlua-sys"
-version = "0.3.1"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa5b61f6c943d77dd6ab5f670865670f65b978400127c8bf31c2df7d6e76289a"
+checksum = "3ec8b54eddb76093069cce9eeffb4c7b3a1a0fe66962d7bd44c4867928149ca3"
 dependencies = [
  "cc",
  "cfg-if",
@@ -1081,9 +1081,9 @@ dependencies = [
 
 [[package]]
 name = "mlua_derive"
-version = "0.9.0-rc.2"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b900bf5619cdf327722cb39424409856a46f3a516628117a896cdbeecc0a9b1"
+checksum = "0f359220f24e6452dd82a3f50d7242d4aab822b5594798048e953d7a9e0314c6"
 dependencies = [
  "itertools",
  "once_cell",
@@ -1091,7 +1091,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "regex",
- "syn 2.0.28",
+ "syn 2.0.29",
 ]
 
 [[package]]
@@ -1240,7 +1240,7 @@ dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 2.0.28",
+ "syn 2.0.29",
 ]
 
 [[package]]
@@ -1328,7 +1328,7 @@ dependencies = [
  "libc",
  "redox_syscall",
  "smallvec",
- "windows-targets 0.48.1",
+ "windows-targets 0.48.5",
 ]
 
 [[package]]
@@ -1420,7 +1420,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "097bf8b99121dfb8c75eed54dfbdbdb1d53e372c53d2353e8a15aad2a479249d"
 dependencies = [
  "quote",
- "syn 2.0.28",
+ "syn 2.0.29",
 ]
 
 [[package]]
@@ -1434,9 +1434,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.32"
+version = "1.0.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50f3b39ccfb720540debaa0164757101c08ecb8d326b15358ce76a62c7e85965"
+checksum = "5267fca4496028628a95160fc423a33e8b2e6af8a5302579e322e4b520293cae"
 dependencies = [
  "proc-macro2",
 ]
@@ -1600,7 +1600,7 @@ checksum = "aafe972d60b0b9bee71a91b92fee2d4fb3c9d7e8f6b179aa99f27203d99a4816"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.28",
+ "syn 2.0.29",
 ]
 
 [[package]]
@@ -1712,7 +1712,7 @@ dependencies = [
 [[package]]
 name = "smithay-drm-extras"
 version = "0.1.0"
-source = "git+https://github.com/Smithay/smithay.git#c569c8732172137169e95e69bd620f81a8a32f2b"
+source = "git+https://github.com/Smithay/smithay.git#e241ccbbc4dfc6ce38e33856d9d159e436db3b5e"
 dependencies = [
  "drm",
  "edid-rs",
@@ -1777,9 +1777,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.28"
+version = "2.0.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04361975b3f5e348b2189d8dc55bc942f278b2d482a6a0365de5bdd62d351567"
+checksum = "c324c494eba9d92503e6f1ef2e6df781e78f6a7705a0202d9801b198807d518a"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1788,9 +1788,9 @@ dependencies = [
 
 [[package]]
 name = "tempfile"
-version = "3.7.1"
+version = "3.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc02fddf48964c42031a0b3fe0428320ecf3a73c401040fc0096f97794310651"
+checksum = "cb94d2f3cc536af71caac6b6fcebf65860b347e7ce0cc9ebe8f70d3e521054ef"
 dependencies = [
  "cfg-if",
  "fastrand",
@@ -1801,22 +1801,22 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.44"
+version = "1.0.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "611040a08a0439f8248d1990b111c95baa9c704c805fa1f62104b39655fd7f90"
+checksum = "97a802ec30afc17eee47b2855fc72e0c4cd62be9b4efe6591edde0ec5bd68d8f"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.44"
+version = "1.0.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "090198534930841fab3a5d1bb637cde49e339654e606195f8d9c76eeb081dc96"
+checksum = "6bb623b56e39ab7dcd4b1b98bb6c8f8d907ed255b18de254088016b27a8ee19b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.28",
+ "syn 2.0.29",
 ]
 
 [[package]]
@@ -1870,9 +1870,9 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "1.31.0"
+version = "1.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40de3a2ba249dcb097e01be5e67a5ff53cf250397715a071a81543e8a832a920"
+checksum = "17ed6077ed6cd6c74735e21f37eb16dc3935f96878b1fe961074089cc80893f9"
 dependencies = [
  "backtrace",
  "bytes",
@@ -1895,7 +1895,7 @@ checksum = "630bdcf245f78637c13ec01ffae6187cca34625e8c63150d424b59e55af2675e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.28",
+ "syn 2.0.29",
 ]
 
 [[package]]
@@ -1946,7 +1946,7 @@ checksum = "5f4f31f56159e98206da9efd823404b79b6ef3143b4a7ab76e67b1751b25a4ab"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.28",
+ "syn 2.0.29",
 ]
 
 [[package]]
@@ -2062,7 +2062,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.28",
+ "syn 2.0.29",
  "wasm-bindgen-shared",
 ]
 
@@ -2084,7 +2084,7 @@ checksum = "54681b18a46765f095758388f2d0cf16eb8d4169b639ab575a8f5693af210c7b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.28",
+ "syn 2.0.29",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -2327,7 +2327,7 @@ version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e686886bc078bc1b0b600cac0147aadb815089b6e4da64016cbd754b6342700f"
 dependencies = [
- "windows-targets 0.48.1",
+ "windows-targets 0.48.5",
 ]
 
 [[package]]
@@ -2345,7 +2345,7 @@ version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
 dependencies = [
- "windows-targets 0.48.1",
+ "windows-targets 0.48.5",
 ]
 
 [[package]]
@@ -2365,17 +2365,17 @@ dependencies = [
 
 [[package]]
 name = "windows-targets"
-version = "0.48.1"
+version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05d4b17490f70499f20b9e791dcf6a299785ce8af4d709018206dc5b4953e95f"
+checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
 dependencies = [
- "windows_aarch64_gnullvm 0.48.0",
- "windows_aarch64_msvc 0.48.0",
- "windows_i686_gnu 0.48.0",
- "windows_i686_msvc 0.48.0",
- "windows_x86_64_gnu 0.48.0",
- "windows_x86_64_gnullvm 0.48.0",
- "windows_x86_64_msvc 0.48.0",
+ "windows_aarch64_gnullvm 0.48.5",
+ "windows_aarch64_msvc 0.48.5",
+ "windows_i686_gnu 0.48.5",
+ "windows_i686_msvc 0.48.5",
+ "windows_x86_64_gnu 0.48.5",
+ "windows_x86_64_gnullvm 0.48.5",
+ "windows_x86_64_msvc 0.48.5",
 ]
 
 [[package]]
@@ -2386,9 +2386,9 @@ checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
-version = "0.48.0"
+version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91ae572e1b79dba883e0d315474df7305d12f569b400fcf90581b06062f7e1bc"
+checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
 
 [[package]]
 name = "windows_aarch64_msvc"
@@ -2398,9 +2398,9 @@ checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.48.0"
+version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2ef27e0d7bdfcfc7b868b317c1d32c641a6fe4629c171b8928c7b08d98d7cf3"
+checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -2410,9 +2410,9 @@ checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
 
 [[package]]
 name = "windows_i686_gnu"
-version = "0.48.0"
+version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "622a1962a7db830d6fd0a69683c80a18fda201879f0f447f065a3b7467daa241"
+checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -2422,9 +2422,9 @@ checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.48.0"
+version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4542c6e364ce21bf45d69fdd2a8e455fa38d316158cfd43b3ac1c5b1b19f8e00"
+checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -2434,9 +2434,9 @@ checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
 
 [[package]]
 name = "windows_x86_64_gnu"
-version = "0.48.0"
+version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca2b8a661f7628cbd23440e50b05d705db3686f894fc9580820623656af974b1"
+checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -2446,9 +2446,9 @@ checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.48.0"
+version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7896dbc1f41e08872e9d5e8f8baa8fdd2677f29468c4e156210174edc7f7b953"
+checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -2458,9 +2458,9 @@ checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
 
 [[package]]
 name = "windows_x86_64_msvc"
-version = "0.48.0"
+version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a515f5799fe4961cb532f983ce2b23082366b898e52ffbce459c86f67c8378a"
+checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
 
 [[package]]
 name = "winit"
@@ -2498,9 +2498,9 @@ dependencies = [
 
 [[package]]
 name = "winnow"
-version = "0.5.10"
+version = "0.5.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5504cc7644f4b593cbc05c4a55bf9bd4e94b867c3c0bd440934174d50482427d"
+checksum = "d09770118a7eb1ccaf4a594a221334119a44a814fcb0d31c5b85e83e97227a97"
 dependencies = [
  "memchr",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1755,6 +1755,7 @@ dependencies = [
  "tokio",
  "tracing-appender",
  "tracing-subscriber",
+ "xdg",
 ]
 
 [[package]]
@@ -2545,6 +2546,12 @@ checksum = "463705a63313cd4301184381c5e8042f0a7e9b4bb63653f216311d4ae74690b7"
 dependencies = [
  "nom",
 ]
+
+[[package]]
+name = "xdg"
+version = "2.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "213b7324336b53d2414b2db8537e56544d981803139155afa84f76eeebb7a546"
 
 [[package]]
 name = "xkbcommon"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,6 +50,7 @@ mlua = { version = "0.9.0-rc.2", features = [
 ] }
 lazy_static = "1.4.0"
 parking_lot = "0.12.1"
+xdg = "2.5.2"
 
 [dependencies.smithay]
 default-features = false

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,7 +40,7 @@ serde = { version = "1.0.183", features = ["derive"] }
 smithay-drm-extras = { git = "https://github.com/Smithay/smithay.git" }
 once_cell = "1.18.0"
 crossbeam-channel = "0.5.8"
-mlua = { version = "0.9.0-rc.2", features = [
+mlua = { version = "0.9.0", features = [
     "luajit",
     "vendored",
     "serialize",

--- a/Makefile
+++ b/Makefile
@@ -1,36 +1,33 @@
 PREFIX ?= /usr
 SYSCONFDIR ?= /etc
 BINDIR = $(PREFIX)/bin
-LIBDIR = $(PREFIX)/lib/stratawm
 SHAREDIR = $(PREFIX)/share
 
-BINARY = stratawm
+APPNAME = stratawm
 LUA_LIB = lua
 ID = com.strata.Compositor
 TARGET = release
 DEBUG ?= 0
 
-TARGET_BIN = $(DESTDIR)$(BINDIR)/$(BINARY)
-TARGET_LIB = $(DESTDIR)$(LIBDIR)
-
-.PHONY: all clean install uninstall
+TARGET_BIN = $(DESTDIR)$(BINDIR)/$(APPNAME)
+TARGET_LIB = $(DESTDIR)$(SHAREDIR)/$(APPNAME)/
 
 ifeq ($(DEBUG),0)
 	TARGET = release
 	ARGS += --release
 endif
 
-all: $(BINARY)
+all: $(APPNAME)
 
-$(BINARY):
+$(APPNAME):
 	cargo build $(ARGS)
 
 clean:
 	cargo clean
 
-install: $(BINARY)
+install: $(APPNAME)
 	cargo build --release
-	install -Dm0755 "target/$(TARGET)/$(BINARY)" "$(TARGET_BIN)"
+	install -Dm0755 "target/$(TARGET)/$(APPNAME)" "$(TARGET_BIN)"
 	mkdir -p "$(TARGET_LIB)"
 	cp -r "lua" "$(TARGET_LIB)"
 

--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,6 @@ clean:
 	cargo clean
 
 install: $(APPNAME)
-	cargo build --release
 	install -Dm0755 "target/$(TARGET)/$(APPNAME)" "$(TARGET_BIN)"
 	mkdir -p "$(TARGET_LIB)"
 	cp -r "lua" "$(TARGET_LIB)"

--- a/lua/strata/init.lua
+++ b/lua/strata/init.lua
@@ -6,8 +6,6 @@ local module = {
 	api = api, -- mlua module
 
 	-- Exposed mlua API functions
-	set_bindings = api.set_bindings,
-	set_rules = api.set_rules,
 	set_config = api.set_config,
 }
 

--- a/lua/strata/init.lua
+++ b/lua/strata/init.lua
@@ -7,6 +7,7 @@ local module = {
 
 	-- Exposed mlua API functions
 	set_config = api.set_config,
+	get_config = api.get_config,
 }
 
 return module

--- a/src/libs/decorations/borders.rs
+++ b/src/libs/decorations/borders.rs
@@ -80,7 +80,7 @@ impl BorderShader {
 		window: &Window,
 		loc: Point<i32, Logical>,
 	) -> PixelShaderElement {
-		let thickness: f32 = CONFIG.options.read().window_decorations.borders.width as f32;
+		let thickness: f32 = CONFIG.options.read().decorations.border.width as f32;
 		let thickness_loc = (thickness as i32, thickness as i32);
 		let thickness_size = ((thickness * 2.0) as i32, (thickness * 2.0) as i32);
 		let geo = Rectangle::from_loc_and_size(
@@ -102,7 +102,7 @@ impl BorderShader {
 		} else {
 			let angle = 45 as f32 * std::f32::consts::PI;
 			let gradient_direction = [angle.cos(), angle.sin()];
-			let elem = if CONFIG.options.read().window_decorations.borders.radius > 0.0 {
+			let elem = if CONFIG.options.read().decorations.border.radius > 0.0 {
 				PixelShaderElement::new(
 					Self::get(renderer).rounded.clone(),
 					geo,
@@ -118,7 +118,7 @@ impl BorderShader {
 						Uniform::new("halfThickness", thickness * 0.5),
 						Uniform::new(
 							"radius",
-							CONFIG.options.read().window_decorations.borders.radius as f32
+							CONFIG.options.read().decorations.border.radius as f32
 								+ thickness + 2.0,
 						),
 						Uniform::new("gradientDirection", gradient_direction),

--- a/src/libs/parse_config.rs
+++ b/src/libs/parse_config.rs
@@ -1,7 +1,6 @@
 use crate::libs::structs::config::*;
 use mlua::{
 	chunk,
-	Function,
 	Lua,
 	LuaSerdeExt,
 	Result,
@@ -18,54 +17,41 @@ impl StrataApi {
 		Ok(())
 	}
 
-	pub fn set_bindings(lua: &Lua, bindings: Table) -> Result<()> {
-		for key in bindings.sequence_values::<Table>() {
-			let table: Table = key?.clone();
-			let keys: Vec<String> = table.get("keys")?;
-			let cmd: Function = table.get("action")?;
-			lua.globals()
-				.get::<&str, Table>("package")?
-				.get::<&str, Table>("loaded")?
-				.get::<&str, Table>("strata")?
-				.get::<&str, Table>("bindings")?
-				.set(keys.clone().concat(), cmd)?;
-			CONFIG
-				.bindings
-				.write()
-				.push(Keybinding { keys: keys.clone(), action: keys.clone().concat() });
-		}
-		Ok(())
-	}
+	// pub fn set_bindings(_lua: &Lua, _bindings: Table) -> Result<()> {
+	// 	for key in bindings.sequence_values::<Table>() {
+	// 		let table: Table = key?.clone();
+	// 		let keys: Vec<String> = table.get("keys")?;
+	// 		let cmd: Function = table.get("action")?;
+	// 		CONFIG
+	// 			.bindings
+	// 			.write()
+	// 			.push(Keybinding { keys: keys.clone(), action: keys.clone().concat() });
+	// 	}
+	// 	Ok(())
+	// }
 
-	pub fn set_rules(lua: &Lua, rules: Table) -> Result<()> {
-		for rule in rules.sequence_values::<Table>() {
-			let table: Table = rule?.clone();
-			let action: Function = table.get("action").ok().unwrap();
-			let rules_triggers: Table = table.clone().get::<&str, Table>("triggers").ok().unwrap();
-			for trigger in rules_triggers.sequence_values::<Value>() {
-				let triggers: Triggers = lua.from_value(trigger?)?;
-				let action_name: String = format!(
-					"{}{}{}",
-					triggers.clone().event,
-					triggers.clone().class_name,
-					triggers.workspace.unwrap_or(-1)
-				);
-				let _ = lua
-					.globals()
-					.get::<&str, Table>("package")?
-					.get::<&str, Table>("loaded")?
-					.get::<&str, Table>("strata")?
-					.get::<&str, Table>("bindings")?
-					.set(action_name.clone(), action.clone())?;
-				CONFIG
-					.rules
-					.write()
-					.push(Rules { triggers: triggers.clone(), action: action_name });
-			}
-		}
-
-		Ok(())
-	}
+	// pub fn set_rules(lua: &Lua, rules: Table) -> Result<()> {
+	// 	for rule in rules.sequence_values::<Table>() {
+	// 		let table: Table = rule?.clone();
+	// 		let action: Function = table.get("action").ok().unwrap();
+	// 		let rules_triggers: Table = table.clone().get::<&str, Table>("triggers").ok().unwrap();
+	// 		for trigger in rules_triggers.sequence_values::<Value>() {
+	// 			let triggers: Triggers = lua.from_value(trigger?)?;
+	// 			let action_name: String = format!(
+	// 				"{}{}{}",
+	// 				triggers.clone().event,
+	// 				triggers.clone().class_name,
+	// 				triggers.workspace.unwrap_or(-1)
+	// 			);
+	// 			CONFIG
+	// 				.rules
+	// 				.write()
+	// 				.push(Rules { triggers: triggers.clone(), action: action_name });
+	// 		}
+	// 	}
+	//
+	// 	Ok(())
+	// }
 
 	pub fn set_config(lua: &Lua, configs: Table) -> Result<()> {
 		println!("Called!");
@@ -74,20 +60,20 @@ impl StrataApi {
 
 			options.autostart = lua.from_value(configs.get("autostart")?)?;
 			options.general = lua.from_value(configs.get("general")?)?;
-			options.window_decorations = lua.from_value(configs.get("decorations")?)?;
+			options.decorations = lua.from_value(configs.get("decorations")?)?;
 			options.tiling = lua.from_value(configs.get("tiling")?)?;
 			options.animations = lua.from_value(configs.get("animations")?)?;
 		}
-		{
-			let mut rules = CONFIG.rules.write();
-			rules.clear();
-			rules.append(&mut lua.from_value(configs.get("rules")?)?);
-		}
-		{
-			let mut bindings = CONFIG.bindings.write();
-			bindings.clear();
-			bindings.append(&mut lua.from_value(configs.get("bindings")?)?);
-		}
+		// {
+		// 	let mut rules = CONFIG.rules.write();
+		// 	rules.clear();
+		// 	rules.append(&mut lua.from_value(configs.get("rules")?)?);
+		// }
+		// {
+		// 	let mut bindings = CONFIG.bindings.write();
+		// 	bindings.clear();
+		// 	bindings.append(&mut lua.from_value(configs.get("bindings")?)?);
+		// }
 
 		Ok(())
 	}
@@ -102,8 +88,8 @@ pub fn parse_config(config_dir: PathBuf, lib_dir: PathBuf) -> Result<()> {
 	let api_submod = get_or_create_module(&lua, "strata.api").unwrap(); // TODO: remove unwrap
 
 	api_submod.set("spawn", lua.create_function(StrataApi::spawn)?)?;
-	api_submod.set("set_bindings", lua.create_function(StrataApi::set_bindings)?)?;
-	api_submod.set("set_rules", lua.create_function(StrataApi::set_rules)?)?;
+	// api_submod.set("set_bindings", lua.create_function(StrataApi::set_bindings)?)?;
+	// api_submod.set("set_rules", lua.create_function(StrataApi::set_rules)?)?;
 	api_submod.set("set_config", lua.create_function(StrataApi::set_config)?)?;
 	api_submod.set("get_config", lua.create_function(StrataApi::get_config)?)?;
 

--- a/src/libs/parse_config.rs
+++ b/src/libs/parse_config.rs
@@ -17,63 +17,11 @@ impl StrataApi {
 		Ok(())
 	}
 
-	// pub fn set_bindings(_lua: &Lua, _bindings: Table) -> Result<()> {
-	// 	for key in bindings.sequence_values::<Table>() {
-	// 		let table: Table = key?.clone();
-	// 		let keys: Vec<String> = table.get("keys")?;
-	// 		let cmd: Function = table.get("action")?;
-	// 		CONFIG
-	// 			.bindings
-	// 			.write()
-	// 			.push(Keybinding { keys: keys.clone(), action: keys.clone().concat() });
-	// 	}
-	// 	Ok(())
-	// }
-
-	// pub fn set_rules(lua: &Lua, rules: Table) -> Result<()> {
-	// 	for rule in rules.sequence_values::<Table>() {
-	// 		let table: Table = rule?.clone();
-	// 		let action: Function = table.get("action").ok().unwrap();
-	// 		let rules_triggers: Table = table.clone().get::<&str, Table>("triggers").ok().unwrap();
-	// 		for trigger in rules_triggers.sequence_values::<Value>() {
-	// 			let triggers: Triggers = lua.from_value(trigger?)?;
-	// 			let action_name: String = format!(
-	// 				"{}{}{}",
-	// 				triggers.clone().event,
-	// 				triggers.clone().class_name,
-	// 				triggers.workspace.unwrap_or(-1)
-	// 			);
-	// 			CONFIG
-	// 				.rules
-	// 				.write()
-	// 				.push(Rules { triggers: triggers.clone(), action: action_name });
-	// 		}
-	// 	}
-	//
-	// 	Ok(())
-	// }
-
-	pub fn set_config(lua: &Lua, configs: Table) -> Result<()> {
+	pub fn set_config(lua: &Lua, configs: Value) -> Result<()> {
 		println!("Called!");
-		{
-			let mut options = CONFIG.options.write();
 
-			options.autostart = lua.from_value(configs.get("autostart")?)?;
-			options.general = lua.from_value(configs.get("general")?)?;
-			options.decorations = lua.from_value(configs.get("decorations")?)?;
-			options.tiling = lua.from_value(configs.get("tiling")?)?;
-			options.animations = lua.from_value(configs.get("animations")?)?;
-		}
-		// {
-		// 	let mut rules = CONFIG.rules.write();
-		// 	rules.clear();
-		// 	rules.append(&mut lua.from_value(configs.get("rules")?)?);
-		// }
-		// {
-		// 	let mut bindings = CONFIG.bindings.write();
-		// 	bindings.clear();
-		// 	bindings.append(&mut lua.from_value(configs.get("bindings")?)?);
-		// }
+		let mut options = CONFIG.options.write();
+		*options = lua.from_value(configs)?;
 
 		Ok(())
 	}
@@ -88,8 +36,6 @@ pub fn parse_config(config_dir: PathBuf, lib_dir: PathBuf) -> Result<()> {
 	let api_submod = get_or_create_module(&lua, "strata.api").unwrap(); // TODO: remove unwrap
 
 	api_submod.set("spawn", lua.create_function(StrataApi::spawn)?)?;
-	// api_submod.set("set_bindings", lua.create_function(StrataApi::set_bindings)?)?;
-	// api_submod.set("set_rules", lua.create_function(StrataApi::set_rules)?)?;
 	api_submod.set("set_config", lua.create_function(StrataApi::set_config)?)?;
 	api_submod.set("get_config", lua.create_function(StrataApi::get_config)?)?;
 

--- a/src/libs/parse_config.rs
+++ b/src/libs/parse_config.rs
@@ -8,8 +8,8 @@ use mlua::{
 	Value,
 };
 use std::{
-	env::var,
 	fs::read_to_string,
+	path::PathBuf,
 };
 
 struct StrataApi;
@@ -99,13 +99,9 @@ impl StrataApi {
 	}
 }
 
-pub fn parse_config() -> Result<()> {
+pub fn parse_config(config_path: PathBuf) -> Result<()> {
 	let lua = Lua::new();
 	let lib_path = "/usr/lib/stratawm/lua";
-	let config_path = format!(
-		"{home}/.config/strata/strata.lua",
-		home = var("HOME").expect("This should always be set!!!")
-	);
 	let config_str = read_to_string(config_path)?;
 
 	// Create a new module

--- a/src/libs/structs/config.rs
+++ b/src/libs/structs/config.rs
@@ -73,7 +73,7 @@ pub struct Triggers {
 #[derive(Debug, Clone, Deserialize)]
 pub struct Rules {
 	pub triggers: Triggers,
-	pub action: String,
+	pub action: String, // FIXME
 }
 
 #[derive(Debug, Clone, Deserialize)]
@@ -91,8 +91,6 @@ pub struct Options {
 	pub decorations: WindowDecorations,
 	pub tiling: Tiling,
 	pub animations: Animations,
-	pub rules: Vec<Rules>,
-	pub bindings: Vec<Keybinding>,
 }
 
 #[derive(Debug, Default)]

--- a/src/libs/structs/config.rs
+++ b/src/libs/structs/config.rs
@@ -8,6 +8,7 @@ lazy_static! {
 }
 
 #[derive(Debug, Default, Deserialize)]
+#[serde(default)]
 pub struct General {
 	pub workspaces: u8,
 	pub gaps_in: i32,
@@ -25,6 +26,7 @@ pub struct WindowDecorations {
 }
 
 #[derive(Debug, Default, Deserialize)]
+#[serde(default)]
 pub struct Border {
 	pub width: u32,
 	pub active: String,
@@ -33,11 +35,13 @@ pub struct Border {
 }
 
 #[derive(Debug, Default, Deserialize)]
+#[serde(default)]
 pub struct Window {
 	pub opacity: f64,
 }
 
 #[derive(Debug, Default, Deserialize)]
+#[serde(default)]
 pub struct Blur {
 	pub enable: bool,
 	pub size: u32,
@@ -46,6 +50,7 @@ pub struct Blur {
 }
 
 #[derive(Debug, Default, Deserialize)]
+#[serde(default)]
 pub struct Shadow {
 	pub enable: bool,
 	pub size: u32,
@@ -54,11 +59,13 @@ pub struct Shadow {
 }
 
 #[derive(Debug, Default, Deserialize)]
+#[serde(default)]
 pub struct Tiling {
 	pub layout: String,
 }
 
 #[derive(Debug, Default, Deserialize)]
+#[serde(default)]
 pub struct Animations {
 	pub enable: bool,
 }
@@ -85,6 +92,7 @@ pub struct Keybinding {
 pub type Cmd = Vec<String>;
 
 #[derive(Debug, Default, Deserialize)]
+#[serde(default)]
 pub struct Options {
 	pub autostart: Vec<Cmd>,
 	pub general: General,

--- a/src/libs/structs/config.rs
+++ b/src/libs/structs/config.rs
@@ -16,15 +16,16 @@ pub struct General {
 }
 
 #[derive(Debug, Default, Deserialize)]
+#[serde(default)]
 pub struct WindowDecorations {
-	pub borders: Borders,
+	pub border: Border,
 	pub window: Window,
 	pub blur: Blur,
-	pub shadows: Shadows,
+	pub shadow: Shadow,
 }
 
 #[derive(Debug, Default, Deserialize)]
-pub struct Borders {
+pub struct Border {
 	pub width: u32,
 	pub active: String,
 	pub inactive: String,
@@ -45,8 +46,8 @@ pub struct Blur {
 }
 
 #[derive(Debug, Default, Deserialize)]
-pub struct Shadows {
-	pub enabled: bool,
+pub struct Shadow {
+	pub enable: bool,
 	pub size: u32,
 	pub blur: u32,
 	pub color: String,
@@ -87,7 +88,7 @@ pub type Cmd = Vec<String>;
 pub struct Options {
 	pub autostart: Vec<Cmd>,
 	pub general: General,
-	pub window_decorations: WindowDecorations,
+	pub decorations: WindowDecorations,
 	pub tiling: Tiling,
 	pub animations: Animations,
 	pub rules: Vec<Rules>,
@@ -97,6 +98,6 @@ pub struct Options {
 #[derive(Debug, Default)]
 pub struct Config {
 	pub options: RwLock<Options>,
-	pub rules: RwLock<Vec<Rules>>,
-	pub bindings: RwLock<Vec<Keybinding>>,
+	// pub rules: RwLock<Vec<Rules>>,
+	// pub bindings: RwLock<Vec<Keybinding>>,
 }

--- a/src/libs/workspaces.rs
+++ b/src/libs/workspaces.rs
@@ -103,7 +103,7 @@ impl Workspace {
 		let mut render_elements: Vec<C> = Vec::new();
 		for element in &self.windows {
 			let window = &element.borrow().window;
-			if CONFIG.options.read().window_decorations.borders.width > 0 {
+			if CONFIG.options.read().decorations.border.width > 0 {
 				render_elements.push(C::from(BorderShader::element(
 					renderer.glow_renderer_mut(),
 					window,

--- a/src/main.rs
+++ b/src/main.rs
@@ -14,7 +14,6 @@ pub use libs::{
 };
 use log::info;
 use std::{
-	env::var,
 	error::Error,
 	io::stdout,
 };
@@ -22,14 +21,16 @@ use tracing_subscriber::fmt::writer::MakeWriterExt;
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn Error>> {
-	let xdg_config_path =
-		xdg::BaseDirectories::with_prefix("strata")?.find_config_file("strata.lua");
-	if let Some(config_path) = xdg_config_path {
-		tokio::spawn(async { parse_config(config_path) }).await??;
+	let xdg = xdg::BaseDirectories::with_prefix("stratawm")?;
+
+	let config_dir = xdg.find_config_file("");
+	let lib_dir = xdg.find_data_file("lua");
+	let log_dir = xdg.get_state_home();
+
+	if let (Some(config_path), Some(data_path)) = (config_dir, lib_dir) {
+		tokio::spawn(async { parse_config(config_path, data_path) }).await??;
 	}
 
-	let log_dir =
-		format!("{}/.strata/stratawm", var("HOME").expect("This variable should be set!!!"));
 	let file_appender = tracing_appender::rolling::never(
 		&log_dir,
 		format!("strata_{}.log", Local::now().format("%Y-%m-%d_%H:%M:%S")),

--- a/src/main.rs
+++ b/src/main.rs
@@ -22,7 +22,12 @@ use tracing_subscriber::fmt::writer::MakeWriterExt;
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn Error>> {
-	let _ = tokio::spawn(async { parse_config() }).await?;
+	let xdg_config_path =
+		xdg::BaseDirectories::with_prefix("strata")?.find_config_file("strata.lua");
+	if let Some(config_path) = xdg_config_path {
+		tokio::spawn(async { parse_config(config_path) }).await??;
+	}
+
 	let log_dir =
 		format!("{}/.strata/stratawm", var("HOME").expect("This variable should be set!!!"));
 	let file_appender = tracing_appender::rolling::never(


### PR DESCRIPTION
This PR implements XDG support to handle:

- Config file location
- Lua lib directory location
- Log directory location

Additionally, I've made it so the config file has to be named `config.lua` so as to not conflict with our `strata` module. This change lets us actually load the config file as a module, which allows the user to write their config however they want, for example split in multiple files.

Also: I deleted `set_bindings` and `set_rules` as there should be no need for these methods (we will want a `create_binding` and `create_rule` later on though)